### PR TITLE
Removed maxdepth argument from find in order to display KDE apps.

### DIFF
--- a/freedesktop/utils.lua
+++ b/freedesktop/utils.lua
@@ -213,7 +213,7 @@ end
 -- @return A table with all .desktop entries.
 function parse_desktop_files(arg)
     local programs = {}
-    local files = get_lines('find '.. arg.dir ..' -maxdepth 1 -name "*.desktop"')
+    local files = get_lines('find '.. arg.dir ..' -name "*.desktop"')
     for file in files do
         arg.file = file
         table.insert(programs, parse_desktop_file(arg))


### PR DESCRIPTION
Hello.

The KDE programs placed the desktop files in `/usr/share/applications/kde4` so the maxdepth argument for `find` inhibited the menu to parse those `.desktop` files.

I don't think this will be such a big performance issue (if you were thinking about this when you implemented it) because there are a few environments that place icons into dirs.
