### PR TITLE
Fix gfind in utils.lua

### DIFF
--- a/freedesktop/utils.lua
+++ b/freedesktop/utils.lua
@@ -185,7 +185,7 @@ function parse_desktop_file(arg)
     -- Split categories into a table.
     if program.Categories then
         program.categories = {}
-        for category in program.Categories:gfind('[^;]+') do
+        for category in program.Categories:gmatch('[^;]+') do
             table.insert(program.categories, category)
         end
     end


### PR DESCRIPTION
gfind method does not exist in 5.2 any more. It was renamed to gmatch
