### PR TITLE
SVG support for menu.lua and utils.lua

### DIFF
--- a/freedesktop/menu.lua
+++ b/freedesktop/menu.lua
@@ -71,17 +71,17 @@ function new(arg)
     end
 
     local menu = {
-        { "Accessories", programs["Utility"], utils.lookup_icon({ icon = 'applications-accessories.png' }) },
-        { "Development", programs["Development"], utils.lookup_icon({ icon = 'applications-development.png' }) },
-        { "Education", programs["Education"], utils.lookup_icon({ icon = 'applications-science.png' }) },
-        { "Games", programs["Game"], utils.lookup_icon({ icon = 'applications-games.png' }) },
-        { "Graphics", programs["Graphics"], utils.lookup_icon({ icon = 'applications-graphics.png' }) },
-        { "Internet", programs["Network"], utils.lookup_icon({ icon = 'applications-internet.png' }) },
-        { "Multimedia", programs["AudioVideo"], utils.lookup_icon({ icon = 'applications-multimedia.png' }) },
-        { "Office", programs["Office"], utils.lookup_icon({ icon = 'applications-office.png' }) },
-        { "Other", programs["Other"], utils.lookup_icon({ icon = 'applications-other.png' }) },
-        { "Settings", programs["Settings"], utils.lookup_icon({ icon = 'preferences-desktop.png' }) },
-        { "System Tools", programs["System"], utils.lookup_icon({ icon = 'applications-system.png' }) },
+        { "Accessories", programs["Utility"], utils.lookup_icon({ icon = 'applications-accessories' }) },
+        { "Development", programs["Development"], utils.lookup_icon({ icon = 'applications-development' }) },
+        { "Education", programs["Education"], utils.lookup_icon({ icon = 'applications-science' }) },
+        { "Games", programs["Game"], utils.lookup_icon({ icon = 'applications-games' }) },
+        { "Graphics", programs["Graphics"], utils.lookup_icon({ icon = 'applications-graphics' }) },
+        { "Internet", programs["Network"], utils.lookup_icon({ icon = 'applications-internet' }) },
+        { "Multimedia", programs["AudioVideo"], utils.lookup_icon({ icon = 'applications-multimedia' }) },
+        { "Office", programs["Office"], utils.lookup_icon({ icon = 'applications-office' }) },
+        { "Other", programs["Other"], utils.lookup_icon({ icon = 'applications-other' }) },
+        { "Settings", programs["Settings"], utils.lookup_icon({ icon = 'preferences-desktop' }) },
+        { "System Tools", programs["System"], utils.lookup_icon({ icon = 'applications-system' }) },
     }
 
     -- Removing empty entries from menu

--- a/freedesktop/utils.lua
+++ b/freedesktop/utils.lua
@@ -23,7 +23,9 @@ all_icon_sizes = {
     '32x32',
     '24x24',
     '22x22',
-    '16x16'
+    '16x16',
+    '8x8',
+    'scalable'
 }
 all_icon_types = {
     'apps',
@@ -59,7 +61,7 @@ function file_exists(filename)
 end
 
 function lookup_icon(arg)
-    if arg.icon:sub(1, 1) == '/' and (arg.icon:find('.+%.png') or arg.icon:find('.+%.xpm')) then
+    if arg.icon:sub(1, 1) == '/' and (arg.icon:find('.+%.png') or arg.icon:find('.+%.xpm') or arg.icon:find('.+%.svg')) then
         -- icons with absolute path and supported (AFAICT) formats
         return arg.icon
     else
@@ -97,12 +99,14 @@ function lookup_icon(arg)
         table.insert(icon_path,  '/usr/share/app-install/icons/')
 
         for i, directory in ipairs(icon_path) do
-            if (arg.icon:find('.+%.png') or arg.icon:find('.+%.xpm')) and file_exists(directory .. arg.icon) then
+            if (arg.icon:find('.+%.png') or arg.icon:find('.+%.xpm') or arg.icon:find('.+%.svg')) and file_exists(directory .. arg.icon) then
                 return directory .. arg.icon
             elseif file_exists(directory .. arg.icon .. '.png') then
                 return directory .. arg.icon .. '.png'
             elseif file_exists(directory .. arg.icon .. '.xpm') then
                 return directory .. arg.icon .. '.xpm'
+            elseif file_exists(directory .. arg.icon .. '.svg') then
+                return directory .. arg.icon .. '.svg'
             end
         end
     end


### PR DESCRIPTION
I added support for the SVG image file format for menu.lua and utils.lua. SVG support is optional according to the freedesktop icon theme specification(http://standards.freedesktop.org/icon-theme-spec/icon-theme-spec-latest.html). Awful handles the SVG format fine, so I only changed some lines in the all_icon_sizes(also added 8x8) and the lookup function. In menu.lua requests were made specifically for PNG files, so I removed that too(I suppose it also enables XPM categories icons).
