### PR TITLE
Fixed bug where awesome-freedesktop crashes when program name is null.

### DIFF
--- a/freedesktop/utils.lua
+++ b/freedesktop/utils.lua
@@ -190,7 +190,7 @@ function parse_desktop_file(arg)
         end
     end
 
-    if program.Exec then
+    if program.Exec and program.Name then
         local cmdline = program.Exec:gsub('%%c', program.Name)
         cmdline = cmdline:gsub('%%[fmuFMU]', '')
         cmdline = cmdline:gsub('%%k', program.file)


### PR DESCRIPTION
awesome-freedesktop would throw an exception and cause awesome to not start properly on my system. I determined that the problem was a program with a null name. While this should never be the case, it is a good idea to check for this to prevent awesome from crashing.
